### PR TITLE
Fix: Update backend dependencies based on maintenance status

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,11 +1,10 @@
 google-api-python-client
-google-auth-httplib2
 google-auth-oauthlib
 aiogoogle
 aiosqlite
 fastapi
 uvicorn[standard]
-APScheduler
+APScheduler~=3.10.4 # Pinned to stable 3.x series, as 4.x is in pre-release
 google-generativeai
 python-json-logger
 pytest


### PR DESCRIPTION
This commit addresses the maintenance status of packages listed in backend/requirements.txt.

- I removed `google-auth-httplib2` as it is deprecated and no longer maintained. The recommendation is to use `google-auth` (already a dependency of other packages) and an HTTP client like `httpx` (already in requirements) directly.
- I pinned `APScheduler` to `~=3.10.4`. Version 4.x is currently in pre-release, so this change ensures the project uses a stable version. I added a comment to requirements.txt explaining this.

Other packages were checked and found to be actively maintained.